### PR TITLE
Add farmlogs-internal repo to project

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,4 +7,8 @@
                  [org.clojure/tools.logging "0.3.1"]]
   :repositories [["primedia"
                   {:url "http://nexus.idg.primedia.com/nexus/content/repositories/primedia"
-                   :sign-releases false}]])
+                   :sign-releases false}]
+                 ["farmlogs-internal"
+                  {:url "s3p://fl-maven-repo/mvn"
+                   :username ~(System/getenv "AMAZON_KEY")
+                   :passphrase ~(System/getenv "AMAZON_SECRET")}]])


### PR DESCRIPTION
There's no officially published clj-config jar.

This is hopefully temporary. I've reached out to RentPath to see if they'll publish a jar.